### PR TITLE
Use proper emoji for simple smile

### DIFF
--- a/emoji-annotation-to-unicode.js
+++ b/emoji-annotation-to-unicode.js
@@ -707,7 +707,7 @@ module.exports = {
   "small_orange_diamond": "1f538",
   "small_red_triangle": "1f53a",
   "small_red_triangle_down": "1f53b",
-  "smile": "1f604",
+  "smile": "1f642",
   "smile_cat": "1f638",
   "smiley": "1f603",
   "smiley_cat": "1f63a",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-annotation-to-unicode",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Emoji annotation to unicode map",
   "main": "emoji-annotation-to-unicode.js",
   "repository": {


### PR DESCRIPTION
The :smile: or :-) emoji used in react-emoji is currently shown as 

http://emojione.com/wp-content/uploads/assets/emojis/1f603.svg

instead of

http://emojione.com/wp-content/uploads/assets/emojis/1f642.svg

This commit changes this.

A simple smile should only show closed mouth and not open mouth like :D or :-D which can be received as demeaning by the recipient.
